### PR TITLE
Use file interface instead of requiring os.File

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ in Charm's [Bubble Tea](https://github.com/charmbracelet/bubbletea) framework.
 
 ## Usage
 
-`NewReader` returns a reader with a `Cancel` function. If the input reader is an
-`*os.File`, the cancel function can be used to interrupt a blocking `Read` call.
+`NewReader` returns a reader with a `Cancel` function. If the input reader is a
+`File`, the cancel function can be used to interrupt a blocking `Read` call.
 In this case, the cancel function returns true if the call was canceled
-successfully. If the input reader is not an `*os.File`, the cancel function does
+successfully. If the input reader is not a `File`, the cancel function does
 nothing and always returns false.
 
 ```go

--- a/cancelreader.go
+++ b/cancelreader.go
@@ -18,6 +18,17 @@ type CancelReader interface {
 	Cancel() bool
 }
 
+// File represents an input/output resource with a file descriptor.
+type File interface {
+	io.ReadWriteCloser
+
+	// Fd returns its file descriptor
+	Fd() uintptr
+
+	// Name returns its file name.
+	Name() string
+}
+
 // fallbackCancelReader implements cancelReader but does not actually support
 // cancelation during an ongoing Read() call. Thus, Cancel() always returns
 // false. However, after calling Cancel(), new Read() calls immediately return

--- a/cancelreader_bsd.go
+++ b/cancelreader_bsd.go
@@ -13,14 +13,14 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// NewReader returns a reader and a cancel function. If the input reader is an
-// *os.File, the cancel function can be used to interrupt a blocking read call.
+// NewReader returns a reader and a cancel function. If the input reader is a
+// File, the cancel function can be used to interrupt a blocking read call.
 // In this case, the cancel function returns true if the call was canceled
-// successfully. If the input reader is not an *os.File, the cancel function
+// successfully. If the input reader is not a File, the cancel function
 // does nothing and always returns false. The BSD and macOS implementation is
 // based on the kqueue mechanism.
 func NewReader(reader io.Reader) (CancelReader, error) {
-	file, ok := reader.(*os.File)
+	file, ok := reader.(File)
 	if !ok {
 		return newFallbackCancelReader(reader)
 	}
@@ -52,9 +52,9 @@ func NewReader(reader io.Reader) (CancelReader, error) {
 }
 
 type kqueueCancelReader struct {
-	file               *os.File
-	cancelSignalReader *os.File
-	cancelSignalWriter *os.File
+	file               File
+	cancelSignalReader File
+	cancelSignalWriter File
 	cancelMixin
 	kQueue       int
 	kQueueEvents [2]unix.Kevent_t

--- a/cancelreader_linux.go
+++ b/cancelreader_linux.go
@@ -13,14 +13,14 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// NewReader returns a reader and a cancel function. If the input reader is an
-// *os.File, the cancel function can be used to interrupt a blocking read call.
+// NewReader returns a reader and a cancel function. If the input reader is a
+// File, the cancel function can be used to interrupt a blocking read call.
 // In this case, the cancel function returns true if the call was canceled
-// successfully. If the input reader is not an *os.File, the cancel function
+// successfully. If the input reader is not a File, the cancel function
 // does nothing and always returns false. The Linux implementation is based on
 // the epoll mechanism.
 func NewReader(reader io.Reader) (CancelReader, error) {
-	file, ok := reader.(*os.File)
+	file, ok := reader.(File)
 	if !ok {
 		return newFallbackCancelReader(reader)
 	}
@@ -60,9 +60,9 @@ func NewReader(reader io.Reader) (CancelReader, error) {
 }
 
 type epollCancelReader struct {
-	file               *os.File
-	cancelSignalReader *os.File
-	cancelSignalWriter *os.File
+	file               File
+	cancelSignalReader File
+	cancelSignalWriter File
 	cancelMixin
 	epoll int
 }

--- a/cancelreader_select.go
+++ b/cancelreader_select.go
@@ -14,14 +14,14 @@ import (
 )
 
 // newSelectCancelReader returns a reader and a cancel function. If the input
-// reader is an *os.File, the cancel function can be used to interrupt a
+// reader is a File, the cancel function can be used to interrupt a
 // blocking call read call. In this case, the cancel function returns true if
-// the call was canceled successfully. If the input reader is not a *os.File or
+// the call was canceled successfully. If the input reader is not a File or
 // the file descriptor is 1024 or larger, the cancel function does nothing and
 // always returns false. The generic unix implementation is based on the posix
 // select syscall.
 func newSelectCancelReader(reader io.Reader) (CancelReader, error) {
-	file, ok := reader.(*os.File)
+	file, ok := reader.(File)
 	if !ok || file.Fd() >= unix.FD_SETSIZE {
 		return newFallbackCancelReader(reader)
 	}
@@ -38,9 +38,9 @@ func newSelectCancelReader(reader io.Reader) (CancelReader, error) {
 }
 
 type selectCancelReader struct {
-	file               *os.File
-	cancelSignalReader *os.File
-	cancelSignalWriter *os.File
+	file               File
+	cancelSignalReader File
+	cancelSignalWriter File
 	cancelMixin
 }
 
@@ -101,7 +101,7 @@ func (r *selectCancelReader) Close() error {
 	return nil
 }
 
-func waitForRead(reader *os.File, abort *os.File) error {
+func waitForRead(reader, abort File) error {
 	readerFd := int(reader.Fd())
 	abortFd := int(abort.Fd())
 

--- a/cancelreader_unix.go
+++ b/cancelreader_unix.go
@@ -7,10 +7,10 @@ import (
 	"io"
 )
 
-// NewReader returns a reader and a cancel function. If the input reader is an
-// *os.File, the cancel function can be used to interrupt a blocking read call.
+// NewReader returns a reader and a cancel function. If the input reader is a
+// File, the cancel function can be used to interrupt a blocking read call.
 // In this case, the cancel function returns true if the call was canceled
-// successfully. If the input reader is not an *os.File or the file descriptor
+// successfully. If the input reader is not a File or the file descriptor
 // is 1024 or larger, the cancel function does nothing and always returns false.
 // The generic unix implementation is based on the posix select syscall.
 func NewReader(reader io.Reader) (CancelReader, error) {

--- a/cancelreader_windows.go
+++ b/cancelreader_windows.go
@@ -16,15 +16,15 @@ import (
 
 var fileShareValidFlags uint32 = 0x00000007
 
-// NewReader returns a reader and a cancel function. If the input reader is an
-// *os.File with the same file descriptor as os.Stdin, the cancel function can
+// NewReader returns a reader and a cancel function. If the input reader is a
+// File with the same file descriptor as os.Stdin, the cancel function can
 // be used to interrupt a blocking read call. In this case, the cancel function
 // returns true if the call was canceled successfully. If the input reader is
-// not an *os.File with the same file descriptor as os.Stdin, the cancel
+// not a File with the same file descriptor as os.Stdin, the cancel
 // function does nothing and always returns false. The Windows implementation
 // is based on WaitForMultipleObject with overlapping reads from CONIN$.
 func NewReader(reader io.Reader) (CancelReader, error) {
-	if f, ok := reader.(*os.File); !ok || f.Fd() != os.Stdin.Fd() {
+	if f, ok := reader.(File); !ok || f.Fd() != os.Stdin.Fd() {
 		return newFallbackCancelReader(reader)
 	}
 


### PR DESCRIPTION
I have some downstreams that won't be able to provide `os.File` but something close to it.