### PR TITLE
Don't leak epoll/kqueue fd on error

### DIFF
--- a/cancelreader_bsd.go
+++ b/cancelreader_bsd.go
@@ -42,7 +42,7 @@ func NewReader(reader io.Reader) (CancelReader, error) {
 
 	r.cancelSignalReader, r.cancelSignalWriter, err = os.Pipe()
 	if err != nil {
-		unix.Close(kQueue)
+		_ = unix.Close(kQueue)
 		return nil, err
 	}
 

--- a/cancelreader_bsd.go
+++ b/cancelreader_bsd.go
@@ -42,6 +42,7 @@ func NewReader(reader io.Reader) (CancelReader, error) {
 
 	r.cancelSignalReader, r.cancelSignalWriter, err = os.Pipe()
 	if err != nil {
+		unix.Close(kQueue)
 		return nil, err
 	}
 

--- a/cancelreader_linux.go
+++ b/cancelreader_linux.go
@@ -37,6 +37,7 @@ func NewReader(reader io.Reader) (CancelReader, error) {
 
 	r.cancelSignalReader, r.cancelSignalWriter, err = os.Pipe()
 	if err != nil {
+		unix.Close(epoll)
 		return nil, err
 	}
 
@@ -45,6 +46,7 @@ func NewReader(reader io.Reader) (CancelReader, error) {
 		Fd:     int32(file.Fd()),
 	})
 	if err != nil {
+		unix.Close(epoll)
 		return nil, fmt.Errorf("add reader to epoll interrest list")
 	}
 
@@ -53,6 +55,7 @@ func NewReader(reader io.Reader) (CancelReader, error) {
 		Fd:     int32(r.cancelSignalReader.Fd()),
 	})
 	if err != nil {
+		unix.Close(epoll)
 		return nil, fmt.Errorf("add reader to epoll interrest list")
 	}
 

--- a/cancelreader_linux.go
+++ b/cancelreader_linux.go
@@ -37,7 +37,7 @@ func NewReader(reader io.Reader) (CancelReader, error) {
 
 	r.cancelSignalReader, r.cancelSignalWriter, err = os.Pipe()
 	if err != nil {
-		unix.Close(epoll)
+		_ = unix.Close(epoll)
 		return nil, err
 	}
 
@@ -46,7 +46,7 @@ func NewReader(reader io.Reader) (CancelReader, error) {
 		Fd:     int32(file.Fd()),
 	})
 	if err != nil {
-		unix.Close(epoll)
+		_ = unix.Close(epoll)
 		return nil, fmt.Errorf("add reader to epoll interrest list")
 	}
 
@@ -55,7 +55,7 @@ func NewReader(reader io.Reader) (CancelReader, error) {
 		Fd:     int32(r.cancelSignalReader.Fd()),
 	})
 	if err != nil {
-		unix.Close(epoll)
+		_ = unix.Close(epoll)
 		return nil, fmt.Errorf("add reader to epoll interrest list")
 	}
 


### PR DESCRIPTION
Close the previously created epoll/kqueue fd in case of a successive
error in NewReader.