### PR TITLE
fix: Keep CTRL+C propagated as signal and not as input

### DIFF
--- a/cancelreader_windows.go
+++ b/cancelreader_windows.go
@@ -199,8 +199,8 @@ func prepareConsole(input windows.Handle) (reset func() error, err error) {
 	newMode &^= windows.ENABLE_LINE_INPUT
 	newMode &^= windows.ENABLE_MOUSE_INPUT
 	newMode &^= windows.ENABLE_WINDOW_INPUT
-	newMode &^= windows.ENABLE_PROCESSED_INPUT
 
+	newMode |= windows.ENABLE_PROCESSED_INPUT
 	newMode |= windows.ENABLE_EXTENDED_FLAGS
 	newMode |= windows.ENABLE_INSERT_MODE
 	newMode |= windows.ENABLE_QUICK_EDIT_MODE


### PR DESCRIPTION
According to the Windows documentation (https://learn.microsoft.com/en-us/windows/console/ctrl-c-and-ctrl-break-signals)

> The SetConsoleMode function can disable the ENABLE_PROCESSED_INPUT input mode
> for a console's input buffer, so CTRL+C is reported as keyboard input rather
> than as a signal.

In the windows implementation, we do:

```go
var newMode uint32
newMode &^= windows.ENABLE_ECHO_INPUT
newMode &^= windows.ENABLE_LINE_INPUT
newMode &^= windows.ENABLE_MOUSE_INPUT
newMode &^= windows.ENABLE_WINDOW_INPUT

newMode &^= windows.ENABLE_PROCESSED_INPUT // This reports CTRL+C as an input rather than as a signal.

newMode |= windows.ENABLE_EXTENDED_FLAGS
newMode |= windows.ENABLE_INSERT_MODE
newMode |= windows.ENABLE_QUICK_EDIT_MODE
```

It should be changed to `newMode |= windows.ENABLE_PROCESSED_INPUT` so we keep the signal propagation.